### PR TITLE
Include token contracts metadata

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -28,6 +28,7 @@ export const APP_VERSION = {
     commit: GIT_COMMIT
 };
 export const DEFAULT_AGE = 30;
+export const DEFAULT_MAX_AGE = 180;
 export const DEFAULT_OFFSET = 0;
 export const DEFAULT_LIMIT = 10;
 export const DEFAULT_CHAIN_ID = "mainnet";

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@ import { Option, program } from "commander";
 
 import pkg from "../package.json" with { type: "json" };
 
+// defaults
 export const DEFAULT_PORT = "3000";
 export const DEFAULT_HOSTNAME = "localhost";
 export const DEFAULT_SSE_PORT = "8080";
@@ -26,6 +27,10 @@ export const APP_VERSION = {
     version: pkg.version,
     commit: GIT_COMMIT
 };
+export const DEFAULT_AGE = 30;
+export const DEFAULT_OFFSET = 0;
+export const DEFAULT_LIMIT = 10;
+export const DEFAULT_CHAIN_ID = "mainnet";
 
 // parse command line options
 const opts = program

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -2,27 +2,41 @@ import { Hono } from 'hono';
 import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { makeUsageQuery } from '../../../handleQuery.js';
-import { chainIdSchema, EvmAddressSchema, metaSchema } from '../../../types/zod.js';
+import { chainIdSchema, evmAddressSchema, limitSchema, metaSchema, offsetSchema } from '../../../types/zod.js';
 import { EVM_SUBSTREAMS_VERSION } from '../index.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
+import { DEFAULT_CHAIN_ID } from '../../../config.js';
 
 const route = new Hono();
 
 const paramSchema = z.object({
-    address: EvmAddressSchema,
+    address: evmAddressSchema,
 });
 
 const querySchema = z.object({
-    chain_id: chainIdSchema,
+    chain_id: z.optional(chainIdSchema),
+    limit: z.optional(limitSchema),
+    offset: z.optional(offsetSchema),
 });
 
 const responseSchema = z.object({
     data: z.array(z.object({
+        // -- block --
+        block_num: z.number(),
         timestamp: z.number(),
         date: z.string(),
-        contract: EvmAddressSchema,
+
+        // -- balance --
+        contract: evmAddressSchema,
         amount: z.string(),
+
+        // -- contract --
+        symbol: z.string(),
+        decimals: z.number(),
+
+        // -- chain --
+        chain_id: chainIdSchema,
     })),
     meta: z.optional(metaSchema),
 });
@@ -53,17 +67,17 @@ const openapi = describeRoute({
 });
 
 route.get('/:address', openapi, validator('param', paramSchema), validator('query', querySchema), async (c) => {
-    const parseAddress = EvmAddressSchema.safeParse(c.req.param("address"));
+    const parseAddress = evmAddressSchema.safeParse(c.req.param("address"));
     if (!parseAddress.success) return c.json({ error: `Invalid EVM address: ${parseAddress.error.message}` }, 400);
 
     const address = parseAddress.data;
-    const chain_id = c.req.query("chain_id");
+    const chain_id = chainIdSchema.safeParse(c.req.query("chain_id")).data ?? DEFAULT_CHAIN_ID;
     const database = `${chain_id}:${EVM_SUBSTREAMS_VERSION}`;
 
     const query = sqlQueries['balances_for_account']?.['evm']; // TODO: Load different chain_type queries based on chain_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { address }, database);
+    return makeUsageQuery(c, [query], { address, chain_id }, database);
 });
 
 export default route;

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -2,28 +2,42 @@ import { Hono } from 'hono';
 import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { makeUsageQuery } from '../../../handleQuery.js';
-import { chainIdSchema, EvmAddressSchema, metaSchema } from '../../../types/zod.js';
+import { chainIdSchema, evmAddressSchema, limitSchema, metaSchema, offsetSchema } from '../../../types/zod.js';
 import { EVM_SUBSTREAMS_VERSION } from '../index.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
+import { DEFAULT_CHAIN_ID } from '../../../config.js';
 
 const route = new Hono();
 
 const paramSchema = z.object({
-    contract: EvmAddressSchema,
+    contract: evmAddressSchema,
 });
 
 const querySchema = z.object({
-    chain_id: chainIdSchema,
     order_by: z.optional(z.string()),
+    chain_id: z.optional(chainIdSchema),
+    limit: z.optional(limitSchema),
+    offset: z.optional(offsetSchema),
 });
 
 const responseSchema = z.object({
     data: z.array(z.object({
+        // -- block --
+        block_num: z.number(),
         timestamp: z.number(),
         date: z.string(),
-        contract: EvmAddressSchema,
+
+        // -- contract --
+        address: evmAddressSchema,
         amount: z.string(),
+
+        // -- contract --
+        symbol: z.string(),
+        decimals: z.number(),
+
+        // -- chain --
+        chain_id: chainIdSchema,
     })),
     meta: z.optional(metaSchema),
 });
@@ -40,10 +54,14 @@ const openapi = describeRoute({
                     schema: resolver(responseSchema), example: {
                         data: [
                             {
-                                "contract": "0x27695e09149adc738a978e9a678f99e4c39e9eb9",
-                                "amount": "1239979319084415",
-                                "timestamp": 1529002377,
-                                "date": "2018-06-14"
+                                "block_num": 20581510,
+                                "timestamp": 1724297855,
+                                "date": "2024-08-22",
+                                "contract": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+                                "amount": "120000000000000000000000",
+                                "decimals": 18,
+                                "symbol": "GRT",
+                                "chain_id": "mainnet"
                             }
                         ]
                     }
@@ -54,17 +72,17 @@ const openapi = describeRoute({
 });
 
 route.get('/:contract', openapi, validator('param', paramSchema), validator('query', querySchema), async (c) => {
-    const parseContract = EvmAddressSchema.safeParse(c.req.param("contract"));
+    const parseContract = evmAddressSchema.safeParse(c.req.param("contract"));
     if (!parseContract.success) return c.json({ error: `Invalid EVM contract: ${parseContract.error.message}` }, 400);
 
     const contract = parseContract.data;
-    const chain_id = c.req.query("chain_id");
+    const chain_id = chainIdSchema.safeParse(c.req.query("chain_id")).data ?? DEFAULT_CHAIN_ID;
     const database = `${chain_id}:${EVM_SUBSTREAMS_VERSION}`;
 
     const query = sqlQueries['holders_for_contract']?.['evm']; // TODO: Load different chain_type queries based on chain_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { contract }, database);
+    return makeUsageQuery(c, [query], { contract, chain_id }, database);
 });
 
 export default route;

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -15,10 +15,10 @@ const paramSchema = z.object({
 });
 
 const querySchema = z.object({
-    order_by: z.optional(z.string()),
     chain_id: z.optional(chainIdSchema),
     limit: z.optional(limitSchema),
     offset: z.optional(offsetSchema),
+    order_by: z.optional(z.string()),
 });
 
 const responseSchema = z.object({

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -33,7 +33,7 @@ const responseSchema = z.object({
         contract: evmAddressSchema,
         from: evmAddressSchema,
         to: evmAddressSchema,
-        value: z.string(),
+        amount: z.string(),
 
         // -- contract --
         symbol: z.string(),

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -19,7 +19,6 @@ const querySchema = z.object({
     limit: z.optional(limitSchema),
     offset: z.optional(offsetSchema),
     age: z.optional(ageSchema),
-    contract: z.optional(evmAddressSchema),
 });
 
 const responseSchema = z.object({

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -2,29 +2,45 @@ import { Hono } from 'hono';
 import { describeRoute } from 'hono-openapi';
 import { resolver, validator } from 'hono-openapi/zod';
 import { makeUsageQuery } from '../../../handleQuery.js';
-import { chainIdSchema, EvmAddressSchema, metaSchema } from '../../../types/zod.js';
+import { ageSchema, chainIdSchema, evmAddressSchema, limitSchema, metaSchema, offsetSchema } from '../../../types/zod.js';
 import { EVM_SUBSTREAMS_VERSION } from '../index.js';
 import { sqlQueries } from '../../../sql/index.js';
 import { z } from 'zod';
+import { DEFAULT_AGE, DEFAULT_CHAIN_ID } from '../../../config.js';
 
 const route = new Hono();
 
 const paramSchema = z.object({
-    address: EvmAddressSchema,
+    address: evmAddressSchema,
 });
 
 const querySchema = z.object({
-    chain_id: chainIdSchema,
+    chain_id: z.optional(chainIdSchema),
+    limit: z.optional(limitSchema),
+    offset: z.optional(offsetSchema),
+    age: z.optional(ageSchema),
+    contract: z.optional(evmAddressSchema),
 });
 
 const responseSchema = z.object({
     data: z.array(z.object({
+        // -- block --
+        block_num: z.number(),
         timestamp: z.number(),
         date: z.string(),
-        contract: EvmAddressSchema,
-        from: EvmAddressSchema,
-        to: EvmAddressSchema,
+
+        // -- transfer --
+        contract: evmAddressSchema,
+        from: evmAddressSchema,
+        to: evmAddressSchema,
         value: z.string(),
+
+        // -- contract --
+        symbol: z.string(),
+        decimals: z.number(),
+
+        // -- chain --
+        chain_id: chainIdSchema,
     })),
     meta: z.optional(metaSchema),
 });
@@ -57,17 +73,18 @@ const openapi = describeRoute({
 });
 
 route.get('/:address', openapi, validator('param', paramSchema), validator('query', querySchema), async (c) => {
-    const parseAddress = EvmAddressSchema.safeParse(c.req.param("address"));
+    const parseAddress = evmAddressSchema.safeParse(c.req.param("address"));
     if (!parseAddress.success) return c.json({ error: `Invalid EVM address: ${parseAddress.error.message}` }, 400);
 
     const address = parseAddress.data;
-    const chain_id = c.req.query("chain_id");
+    const chain_id = chainIdSchema.safeParse(c.req.query("chain_id")).data ?? DEFAULT_CHAIN_ID;
+    const age = ageSchema.safeParse(c.req.query("age")).data ?? DEFAULT_AGE;
     const database = `${chain_id}:${EVM_SUBSTREAMS_VERSION}`;
 
     const query = sqlQueries['transfers_for_account']?.['evm']; // TODO: Load different chain_type queries based on chain_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { address }, database);
+    return makeUsageQuery(c, [query], { address, age, chain_id }, database);
 });
 
 export default route;

--- a/src/sql/balances_for_account/evm.sql
+++ b/src/sql/balances_for_account/evm.sql
@@ -4,8 +4,18 @@ SELECT
     date,
     CAST(contract, 'String') AS contract,
     CAST(new_balance, 'String') AS amount,
-    contracts.decimals as decimals,
-    contracts.symbol as symbol,
+    multiIf(
+        contract = 'native' AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
+        contracts.decimals
+    ) AS decimals,
+    multiIf(
+        contract = 'native' AND chain_id = 'mainnet', 'ETH',
+        contract = 'native' AND chain_id = 'arbitrum-one', 'ETH',
+        contract = 'native' AND chain_id = 'base', 'ETH',
+        contract = 'native' AND chain_id = 'bnb', 'BNB',
+        contract = 'native' AND chain_id = 'matic', 'POL',
+        contracts.symbol
+    ) AS symbol,
     {chain_id: String} as chain_id
 FROM balances FINAL
 LEFT JOIN contracts

--- a/src/sql/balances_for_account/evm.sql
+++ b/src/sql/balances_for_account/evm.sql
@@ -1,8 +1,15 @@
 SELECT
-contract,
-CAST(new_balance, 'String') AS amount,
-toUnixTimestamp(timestamp) as timestamp,
-date
-FROM balances
-WHERE owner = {address: String} AND new_balance > 0
+    block_num,
+    toUnixTimestamp(timestamp) as timestamp,
+    date,
+    CAST(contract, 'String') AS contract,
+    CAST(new_balance, 'String') AS amount,
+    contracts.decimals as decimals,
+    contracts.symbol as symbol,
+    {chain_id: String} as chain_id
+FROM balances FINAL
+LEFT JOIN contracts
+    ON balances.contract = contracts.address
+WHERE
+    owner = {address: String} AND new_balance > 0
 ORDER BY block_num DESC;

--- a/src/sql/balances_for_account/evm.sql
+++ b/src/sql/balances_for_account/evm.sql
@@ -5,15 +5,15 @@ SELECT
     CAST(contract, 'String') AS contract,
     CAST(new_balance, 'String') AS amount,
     multiIf(
-        contract = 'native' AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
         contracts.decimals
     ) AS decimals,
     multiIf(
-        contract = 'native' AND chain_id = 'mainnet', 'ETH',
-        contract = 'native' AND chain_id = 'arbitrum-one', 'ETH',
-        contract = 'native' AND chain_id = 'base', 'ETH',
-        contract = 'native' AND chain_id = 'bnb', 'BNB',
-        contract = 'native' AND chain_id = 'matic', 'POL',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'mainnet', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'arbitrum-one', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'base', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'bnb', 'BNB',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'matic', 'POL',
         contracts.symbol
     ) AS symbol,
     {chain_id: String} as chain_id

--- a/src/sql/holders_for_contract/evm.sql
+++ b/src/sql/holders_for_contract/evm.sql
@@ -5,15 +5,15 @@ SELECT
     owner as address,
     CAST(new_balance, 'String') AS amount,
     multiIf(
-        contract = 'native' AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
         contracts.decimals
     ) AS decimals,
     multiIf(
-        contract = 'native' AND chain_id = 'mainnet', 'ETH',
-        contract = 'native' AND chain_id = 'arbitrum-one', 'ETH',
-        contract = 'native' AND chain_id = 'base', 'ETH',
-        contract = 'native' AND chain_id = 'bnb', 'BNB',
-        contract = 'native' AND chain_id = 'matic', 'POL',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'mainnet', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'arbitrum-one', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'base', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'bnb', 'BNB',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'matic', 'POL',
         contracts.symbol
     ) AS symbol,
     {chain_id: String} as chain_id

--- a/src/sql/holders_for_contract/evm.sql
+++ b/src/sql/holders_for_contract/evm.sql
@@ -1,8 +1,15 @@
 SELECT
-owner as address,
-CAST(new_balance, 'String') AS amount,
-toUnixTimestamp(timestamp) as timestamp,
-date
-FROM balances
-WHERE contract = {contract: String} AND new_balance > 0
+    block_num,
+    toUnixTimestamp(timestamp) as timestamp,
+    date,
+    owner as address,
+    CAST(new_balance, 'String') AS amount,
+    contracts.decimals as decimals,
+    contracts.symbol as symbol,
+    {chain_id: String} as chain_id
+FROM balances FINAL
+LEFT JOIN contracts
+    ON balances.contract = contracts.address
+WHERE
+    contract = {contract: String} AND new_balance > 0
 ORDER BY amount DESC;

--- a/src/sql/holders_for_contract/evm.sql
+++ b/src/sql/holders_for_contract/evm.sql
@@ -4,8 +4,18 @@ SELECT
     date,
     owner as address,
     CAST(new_balance, 'String') AS amount,
-    contracts.decimals as decimals,
-    contracts.symbol as symbol,
+    multiIf(
+        contract = 'native' AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
+        contracts.decimals
+    ) AS decimals,
+    multiIf(
+        contract = 'native' AND chain_id = 'mainnet', 'ETH',
+        contract = 'native' AND chain_id = 'arbitrum-one', 'ETH',
+        contract = 'native' AND chain_id = 'base', 'ETH',
+        contract = 'native' AND chain_id = 'bnb', 'BNB',
+        contract = 'native' AND chain_id = 'matic', 'POL',
+        contracts.symbol
+    ) AS symbol,
     {chain_id: String} as chain_id
 FROM balances FINAL
 LEFT JOIN contracts

--- a/src/sql/transfers_for_account/evm.sql
+++ b/src/sql/transfers_for_account/evm.sql
@@ -2,12 +2,22 @@ SELECT
     block_num,
     toUnixTimestamp(timestamp) as timestamp,
     date,
-    contract,
+    CAST(contract, 'String') AS contract,
     from,
     to,
-    CAST(value, 'String') AS value,
-    contracts.decimals as decimals,
-    contracts.symbol as symbol,
+    CAST(value, 'String') AS amount,
+    multiIf(
+        contract = 'native' AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
+        contracts.decimals
+    ) AS decimals,
+    multiIf(
+        contract = 'native' AND chain_id = 'mainnet', 'ETH',
+        contract = 'native' AND chain_id = 'arbitrum-one', 'ETH',
+        contract = 'native' AND chain_id = 'base', 'ETH',
+        contract = 'native' AND chain_id = 'bnb', 'BNB',
+        contract = 'native' AND chain_id = 'matic', 'POL',
+        contracts.symbol
+    ) AS symbol,
     {chain_id: String} as chain_id
 FROM transfers
 LEFT JOIN contracts

--- a/src/sql/transfers_for_account/evm.sql
+++ b/src/sql/transfers_for_account/evm.sql
@@ -7,15 +7,15 @@ SELECT
     to,
     CAST(value, 'String') AS amount,
     multiIf(
-        contract = 'native' AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
         contracts.decimals
     ) AS decimals,
     multiIf(
-        contract = 'native' AND chain_id = 'mainnet', 'ETH',
-        contract = 'native' AND chain_id = 'arbitrum-one', 'ETH',
-        contract = 'native' AND chain_id = 'base', 'ETH',
-        contract = 'native' AND chain_id = 'bnb', 'BNB',
-        contract = 'native' AND chain_id = 'matic', 'POL',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'mainnet', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'arbitrum-one', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'base', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'bnb', 'BNB',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND chain_id = 'matic', 'POL',
         contracts.symbol
     ) AS symbol,
     {chain_id: String} as chain_id

--- a/src/sql/transfers_for_account/evm.sql
+++ b/src/sql/transfers_for_account/evm.sql
@@ -1,10 +1,17 @@
 SELECT
-contract,
-from,
-to,
-CAST(value, 'String') AS value,
-toUnixTimestamp(timestamp) as timestamp,
-date
+    block_num,
+    toUnixTimestamp(timestamp) as timestamp,
+    date,
+    contract,
+    from,
+    to,
+    CAST(value, 'String') AS value,
+    contracts.decimals as decimals,
+    contracts.symbol as symbol,
+    {chain_id: String} as chain_id
 FROM transfers
-WHERE from = {address: String} OR to = {address: String}
+LEFT JOIN contracts
+    ON transfers.contract = contracts.address
+WHERE
+    date >= Date(now()) - {age: Int} AND (from = {address: String} OR to = {address: String})
 ORDER BY block_num DESC;

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -41,8 +41,11 @@ export const metaSchema = z.object({
     duration_ms: z.optional(z.number()),
 });
 
-export const EvmAddressSchema = evmAddress.toLowerCase().transform((addr) => addr.length == 40 ? `0x${addr}` : addr).pipe(z.string());
+export const evmAddressSchema = evmAddress.toLowerCase().transform((addr) => addr.length == 40 ? `0x${addr}` : addr).pipe(z.string());
 export const chainIdSchema = z.enum(['mainnet', 'bsc', 'base']);
+export const ageSchema = z.coerce.number().int().min(1).max(365);
+export const limitSchema = z.coerce.number().int().min(1).max(500);
+export const offsetSchema = z.coerce.number().int().min(0).max(500);
 
 // ----------------------
 // API Responses

--- a/src/types/zod.ts
+++ b/src/types/zod.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { DEFAULT_AGE, DEFAULT_LIMIT, DEFAULT_MAX_AGE } from "../config.js";
 
 // ----------------------
 // Common schemas
@@ -43,9 +44,9 @@ export const metaSchema = z.object({
 
 export const evmAddressSchema = evmAddress.toLowerCase().transform((addr) => addr.length == 40 ? `0x${addr}` : addr).pipe(z.string());
 export const chainIdSchema = z.enum(['mainnet', 'bsc', 'base']);
-export const ageSchema = z.coerce.number().int().min(1).max(365);
-export const limitSchema = z.coerce.number().int().min(1).max(500);
-export const offsetSchema = z.coerce.number().int().min(0).max(500);
+export const ageSchema = z.coerce.number().int().min(1).max(DEFAULT_MAX_AGE).default(DEFAULT_AGE);
+export const limitSchema = z.coerce.number().int().min(1).max(500).default(DEFAULT_LIMIT);
+export const offsetSchema = z.coerce.number().int().min(0).max(500).default(0);
 
 // ----------------------
 // API Responses


### PR DESCRIPTION
- Add `offset` & `limit` params
- Add `age` param for Transfers (default last 30 days, max 180 days)
- add `contract` filter to get balance & transfers

## Add `symbol` & `decimals` for tokens

```json
{
      "block_num": 22068409,
      "timestamp": 1742236235,
      "date": "2025-03-17",
      "contract": "0xdac17f958d2ee523a2206206994597c13d831ec7",
      "amount": "990965806490",
      "decimals": 6,
      "symbol": "USDT",
      "chain_id": "mainnet"
    },
    {
      "block_num": 22067850,
      "timestamp": 1742229491,
      "date": "2025-03-17",
      "contract": "native",
      "amount": "3134000000000001",
      "decimals": 18,
      "symbol": "ETH",
      "chain_id": "mainnet"
    }
```

## Handling Native `symbol` & `decimals`
```sql
    multiIf(
        contract = 'native' AND chain_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
        contracts.decimals
    ) AS decimals,
    multiIf(
        contract = 'native' AND chain_id = 'mainnet', 'ETH',
        contract = 'native' AND chain_id = 'arbitrum-one', 'ETH',
        contract = 'native' AND chain_id = 'base', 'ETH',
        contract = 'native' AND chain_id = 'bnb', 'BNB',
        contract = 'native' AND chain_id = 'matic', 'POL',
        contracts.symbol
    ) AS symbol,
```