### PR TITLE
Support reporting CH query progress for MCP

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,6 +4,7 @@
     "": {
       "name": "erc20-token-api",
       "dependencies": {
+        "@clickhouse/client": "^1.11.0",
         "@clickhouse/client-web": "latest",
         "@hono/zod-openapi": "^0.19.0",
         "@hono/zod-validator": "^0.4.3",
@@ -29,7 +30,9 @@
 
     "@asteasolutions/zod-to-openapi": ["@asteasolutions/zod-to-openapi@7.3.0", "", { "dependencies": { "openapi3-ts": "^4.1.2" }, "peerDependencies": { "zod": "^3.20.2" } }, "sha512-7tE/r1gXwMIvGnXVUdIqUhCU1RevEFC4Jk6Bussa0fk1ecbnnINkZzj1EOAJyE/M3AI25DnHT/zKQL1/FPFi8Q=="],
 
-    "@clickhouse/client-common": ["@clickhouse/client-common@1.10.1", "", {}, "sha512-Duh3cign2ChvXABpjVj9Hkz5y20Zf48OE0Y50S4qBVPdhI81S4Rh4MI/bEwvwMnzHubSkiEQ+VhC5HzV8ybnpg=="],
+    "@clickhouse/client": ["@clickhouse/client@1.11.0", "", { "dependencies": { "@clickhouse/client-common": "1.11.0" } }, "sha512-VYTQfR0y/BtrIDEjuSce1zv85OvHak5sUhZVyNYJzbAgWHy3jFf8Os7FdUSeqyKav0xGGy+2X+dRanTFjI5Oug=="],
+
+    "@clickhouse/client-common": ["@clickhouse/client-common@1.11.0", "", {}, "sha512-O0xbwv7HiMXayokrf5dYIBpjBnYekcOXWz60T1cXLmiZ8vgrfNRCiOpybJkrMXKnw9D0mWCgPUu/rgMY7U1f4g=="],
 
     "@clickhouse/client-web": ["@clickhouse/client-web@1.10.1", "", { "dependencies": { "@clickhouse/client-common": "1.10.1" } }, "sha512-ai1GxYG/QgaitRvQi01O9NONgeJccKMnUn1j30rECaEDwkLf1er5Jv5jpDA7abBaYinBpgWgOStb1jG2UVQP2Q=="],
 
@@ -350,6 +353,8 @@
     "zod-openapi": ["zod-openapi@4.2.3", "", { "peerDependencies": { "zod": "^3.21.4" } }, "sha512-i0SqpcdXfsvVWTIY1Jl3Tk421s9fBIkpXvaA86zDas+8FjfZjm+GX6ot6SPB2SyuHwUNTN02gE5uIVlYXlyrDQ=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.24.3", "", { "peerDependencies": { "zod": "^3.24.1" } }, "sha512-HIAfWdYIt1sssHfYZFCXp4rU1w2r8hVVXYIlmoa0r0gABLs5di3RCqPU5DDROogVz1pAdYBaz7HK5n9pSUNs3A=="],
+
+    "@clickhouse/client-web/@clickhouse/client-common": ["@clickhouse/client-common@1.10.1", "", {}, "sha512-Duh3cign2ChvXABpjVj9Hkz5y20Zf48OE0Y50S4qBVPdhI81S4Rh4MI/bEwvwMnzHubSkiEQ+VhC5HzV8ybnpg=="],
 
     "@tokenizer/inflate/debug": ["debug@4.4.0", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA=="],
 

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
         "inspector": "bunx @modelcontextprotocol/inspector"
     },
     "dependencies": {
+        "@clickhouse/client": "^1.11.0",
         "@clickhouse/client-web": "latest",
         "@hono/zod-openapi": "^0.19.0",
         "@hono/zod-validator": "^0.4.3",

--- a/src/clickhouse/client.ts
+++ b/src/clickhouse/client.ts
@@ -8,14 +8,15 @@ const client = (database?: string) => {
         database,
         clickhouse_settings: {
             allow_experimental_object_type: 1,
-            exact_rows_before_limit: 1, // Needed for computing pagination but does come with performance cost
             output_format_json_quote_64bit_integers: 0,
-            readonly: "1"
+            readonly: "1",
+            interactive_delay: '500000', // Interval between query progress reports in microseconds
+            max_execution_time: 10, // 10 seconds query timeout to match `fetch` MCP timeout
         },
         application: APP_NAME,
     });
  
     return c;
-}
+};
 
 export default client;

--- a/src/clickhouse/makeQuery.ts
+++ b/src/clickhouse/makeQuery.ts
@@ -1,36 +1,81 @@
-import * as crypto from 'node:crypto'
+import * as crypto from 'node:crypto';
 import client from "./client.js";
 
 import { logger } from "../logger.js";
 import * as prometheus from "../prometheus.js";
 
 import type { ResponseJSON } from "@clickhouse/client-web";
+import { isProgressRow, ProgressRow } from "@clickhouse/client";
 import { config } from "../config.js";
+import { Progress } from 'fastmcp';
 
-export async function makeQuery<T = unknown>(query: string, query_params?: Record<string, unknown>, database?: string) {
+export async function makeQuery<T = unknown>(
+    query: string,
+    query_params?: Record<string, unknown>,
+    database?: string,
+    reportProgressMCP?: (progress: Progress) => Promise<void>
+) {
     const query_id = crypto.randomUUID();
     logger.trace({ query_id, database, query, query_params });
 
-    const response = await client(database).query({ query, query_params, format: "JSON", query_id });
-    const data: ResponseJSON<T> = await response.json();
+    const response = await client(database).query({ query, query_params, format: "JSONEachRowWithProgress", query_id });
+    const stream = response.stream<T>();
+    const data: T[] = [];
+    let rows_before_limit_at_least = 0;
+    let statistics = {
+        bytes_read: 0,
+        rows_read: 0,
+        elapsed: 0
+    };
+
+    // Stream rows for tracking query progress
+    for await (const rows of stream) {
+        for (const row of rows) {
+            try {
+                const decodedRow = row.json() as ProgressRow | { row?: T, rows_before_limit_at_least?: number, meta?: any[]; };
+                if (isProgressRow(decodedRow)) {
+                    // Send notification if query is coming from MCP
+                    if (reportProgressMCP)
+                        reportProgressMCP({
+                            progress: Number(decodedRow.progress.read_rows),
+                            total: Number(decodedRow.progress.total_rows_to_read)
+                        });
+
+                    statistics = {
+                        bytes_read: Number(decodedRow.progress.read_bytes),
+                        rows_read: Number(decodedRow.progress.read_rows),
+                        elapsed: Number(decodedRow.progress.elapsed_ns) / 10 ** 9,
+                    };
+                } else if (decodedRow.rows_before_limit_at_least) {
+                    rows_before_limit_at_least = decodedRow.rows_before_limit_at_least;
+                } else if (decodedRow.row) {
+                    data.push(decodedRow.row);
+                }
+            } catch (err) {
+                throw new Error(`Error streaming response: ${err}`);
+            }
+        }
+    }
+
+    const responseJson: ResponseJSON<T> = { data, statistics, rows: data.length, rows_before_limit_at_least };
     prometheus.queries.inc();
 
     if (response.query_id !== query_id) throw new Error(`Wrong query ID for query: sent ${query_id} / received ${response.query_id}`);
 
-    if (data.statistics) {
-        prometheus.bytes_read.observe(data.statistics.bytes_read);
-        prometheus.rows_read.observe(data.statistics.rows_read);
-        prometheus.elapsed_seconds.observe(data.statistics.elapsed);
+    if (responseJson.statistics) {
+        prometheus.bytes_read.observe(responseJson.statistics.bytes_read);
+        prometheus.rows_read.observe(responseJson.statistics.rows_read);
+        prometheus.elapsed_seconds.observe(responseJson.statistics.elapsed);
 
-        if (data.statistics.rows_read > config.maxRowsTrigger || data.statistics.bytes_read > config.maxBytesTrigger)
+        if (responseJson.statistics.rows_read > config.maxRowsTrigger || responseJson.statistics.bytes_read > config.maxBytesTrigger)
             prometheus.large_queries.inc({
                 query_id,
-                bytes_read: data.statistics.bytes_read,
-                rows_read: data.statistics.rows_read,
-                elapsed_seconds: data.statistics.elapsed
+                bytes_read: responseJson.statistics.bytes_read,
+                rows_read: responseJson.statistics.rows_read,
+                elapsed_seconds: responseJson.statistics.elapsed
             });
     }
 
-    logger.trace({ query_id: response.query_id, statistics: data.statistics, rows: data.rows, rows_before_limit_at_least: data.rows_before_limit_at_least });
-    return data;
+    logger.trace({ query_id: response.query_id, statistics: responseJson.statistics, rows: responseJson.rows, rows_before_limit_at_least: responseJson.rows_before_limit_at_least });
+    return responseJson;
 }

--- a/src/mcp/tools.ts
+++ b/src/mcp/tools.ts
@@ -7,8 +7,8 @@ export default [
         name: "list_databases",
         description: "List available databases",
         parameters: z.object({}), // Always needs a parameter (even if empty)
-        execute: async () => {
-            return runSQLMCP("SHOW DATABASES");
+        execute: async ({ reportProgress }) => {
+            return runSQLMCP("SHOW DATABASES", reportProgress);
         },
     },
     {
@@ -17,9 +17,9 @@ export default [
         parameters: z.object({
             database: z.string() // TODO: Add validation for allowed databases on ClickHouse side (user permissions)
         }),
-        execute: async (args) => {
+        execute: async (args, { reportProgress }) => {
             // Filter out backfill tables as well (TODO: could be done with user permissions ?)
-            return runSQLMCP(`SHOW TABLES FROM ${escapeSQL(args.database)} NOT LIKE '%backfill%'`);
+            return runSQLMCP(`SHOW TABLES FROM ${escapeSQL(args.database)} NOT LIKE '%backfill%'`, reportProgress);
         },
     },
     {
@@ -29,8 +29,8 @@ export default [
             database: z.string(),
             table: z.string(),
         }),
-        execute: async (args) => {
-            return runSQLMCP(`DESCRIBE ${escapeSQL(args.database)}.${escapeSQL(args.table)}`);
+        execute: async (args, { reportProgress }) => {
+            return runSQLMCP(`DESCRIBE ${escapeSQL(args.database)}.${escapeSQL(args.table)}`, reportProgress);
         },
     },
     {
@@ -39,8 +39,8 @@ export default [
         parameters: z.object({
             query: z.string()
         }),
-        execute: async (args) => {
-            return runSQLMCP(args.query);
+        execute: async (args, { reportProgress }) => {
+            return runSQLMCP(args.query, reportProgress);
         },
     },
 ] as Tool<undefined, z.ZodTypeAny>[];

--- a/src/mcp/utils.ts
+++ b/src/mcp/utils.ts
@@ -1,13 +1,13 @@
 // From https://github.com/ClickHouse/clickhouse-js/blob/6e26010036bc108c835d16c5a4904c6dc6039e70/packages/client-common/src/data_formatter/format_query_params.ts#L5
 // Allows for safe quoting of variables in SQL queries when not able to use query params
 import { formatQueryParams } from "@clickhouse/client-common";
-import { UserError } from "fastmcp";
+import { Progress, UserError } from "fastmcp";
 import { makeQuery } from "../clickhouse/makeQuery.js";
 
-export async function runSQLMCP(sql: string): Promise<string> {
+export async function runSQLMCP(sql: string, reportProgress?: (progress: Progress) => Promise<void>): Promise<string> {
     let response;
     try {
-        response = await makeQuery(sql);
+        response = await makeQuery(sql, {}, undefined, reportProgress);
     } catch (error) {
         throw new UserError(`Error while running SQL query: ${error}`);
     }


### PR DESCRIPTION
- Switch query output format from `JSON` to `JSONEachRowWithProgress`
- Use MCP notifications to report on ClickHouse query progress (rows)
- Make ClickHouse query timeout same as MCP `fetch` (10 seconds)