### PR TITLE
add `/tokens/evm` endpoint

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "@hono/zod-validator": "^0.4.3",
         "@modelcontextprotocol/sdk": "^1.6.1",
         "@pinax/graph-networks-registry": "^0.6.7",
+        "@web3icons/core": "^4.0.10",
         "commander": "latest",
         "dotenv": "latest",
         "fastmcp": "^1.20.3",
@@ -66,6 +67,10 @@
     "@types/ws": ["@types/ws@8.5.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-bd/YFLW+URhBzMXurx7lWByOu+xzU9+kb3RboOteXYDfW+tr+JZa99OyNmPINEGB/ahzKrEuc8rcv4gnpJmxTw=="],
 
     "@valibot/to-json-schema": ["@valibot/to-json-schema@1.0.0-rc.0", "", { "peerDependencies": { "valibot": "^1.0.0 || ^1.0.0-beta.5 || ^1.0.0-rc" } }, "sha512-F3WDgnPzcDs9Y8qZwU9qfPnEJBQ6lCMCFjI7VsMjAza6yAixGr4cZ50gOy6zniSCk49GkFvq2a6cBKfZjTpyOw=="],
+
+    "@web3icons/common": ["@web3icons/common@0.11.8", "", { "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-CkK5tRPTPFXdY+ieh67b9MWyqpHCStRILqTMNOAeXuXVGc8aC4MljeuJJE3yX/eOS8TDw/ak1othijilIr0dHg=="],
+
+    "@web3icons/core": ["@web3icons/core@4.0.10", "", { "dependencies": { "@web3icons/common": "0.11.8" }, "peerDependencies": { "typescript": "^5.0.0" } }, "sha512-WVbdDzfFjImEbpLKx3DQA+XQIjHqf/sgPVMN7o/R56X+mWz0fkzKtHQDu+d7X6LcUh7CuVm6RoDPs3nrgqOBmw=="],
 
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
         "@hono/zod-validator": "^0.4.3",
         "@modelcontextprotocol/sdk": "^1.6.1",
         "@pinax/graph-networks-registry": "^0.6.7",
+        "@web3icons/core": "^4.0.10",
         "commander": "latest",
         "dotenv": "latest",
         "fastmcp": "^1.20.3",

--- a/src/handleQuery.ts
+++ b/src/handleQuery.ts
@@ -25,7 +25,7 @@ export async function makeUsageQuery(ctx: Context, query: string[], query_params
         if (result.data.length === 0) {
             return APIErrorResponse(ctx, 404, "not_found_data", `No data found`);
         }
-        return ctx.json({
+        return {
             data: result.data,
             meta: {
                 statistics: result.statistics ?? null,
@@ -34,7 +34,7 @@ export async function makeUsageQuery(ctx: Context, query: string[], query_params
                 request_time,
                 duration_ms: Number(new Date()) - Number(request_time),
             }
-        });
+        };
     } catch (err) {
         return APIErrorResponse(ctx, 500, "bad_database_response", err);
     }

--- a/src/routes/token/balances/evm.ts
+++ b/src/routes/token/balances/evm.ts
@@ -84,7 +84,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
     const query = sqlQueries['balances_for_account']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { address, network_id, contract }, database);
+    return c.json(makeUsageQuery(c, [query], { address, network_id, contract }, database));
 });
 
 export default route;

--- a/src/routes/token/holders/evm.ts
+++ b/src/routes/token/holders/evm.ts
@@ -82,7 +82,7 @@ route.get('/:contract', openapi, validator('param', paramSchema), validator('que
     const query = sqlQueries['holders_for_contract']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { contract, network_id }, database);
+    return c.json(makeUsageQuery(c, [query], { contract, network_id }, database));
 });
 
 export default route;

--- a/src/routes/token/index.ts
+++ b/src/routes/token/index.ts
@@ -2,6 +2,7 @@ import { Hono } from 'hono'
 import balances from "./balances/index.js";
 import transfers from "./transfers/index.js";
 import holders from "./holders/index.js";
+import tokens from "./tokens/index.js";
 
 export const EVM_SUBSTREAMS_VERSION = "evm-tokens@v1.8.2:db_out";
 
@@ -10,5 +11,6 @@ const router = new Hono()
 router.route('/balances', balances)
 router.route('/transfers', transfers)
 router.route('/holders', holders)
+router.route('/tokens', tokens)
 
 export default router

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -35,7 +35,7 @@ const responseSchema = z.object({
         decimals: z.number(),
 
         // -- token --
-        total_supply: z.number(),
+        total_supply: z.string(),
         holders: z.number(),
 
         // -- chain --

--- a/src/routes/token/tokens/evm.ts
+++ b/src/routes/token/tokens/evm.ts
@@ -1,0 +1,91 @@
+import { Hono } from 'hono';
+import { describeRoute } from 'hono-openapi';
+import { resolver, validator } from 'hono-openapi/zod';
+import { makeUsageQuery } from '../../../handleQuery.js';
+import { networkIdSchema, evmAddressSchema, metaSchema } from '../../../types/zod.js';
+import { EVM_SUBSTREAMS_VERSION } from '../index.js';
+import { sqlQueries } from '../../../sql/index.js';
+import { z } from 'zod';
+import { DEFAULT_NETWORK_ID } from '../../../config.js';
+
+const route = new Hono();
+
+const paramSchema = z.object({
+    contract: evmAddressSchema,
+});
+
+const querySchema = z.object({
+    network_id: z.optional(networkIdSchema),
+});
+
+const responseSchema = z.object({
+    data: z.array(z.object({
+        // -- block --
+        block_num: z.number(),
+        timestamp: z.number(),
+        date: z.string(),
+
+        // -- contract --
+        address: evmAddressSchema,
+
+        // -- contract --
+        name: z.string(),
+        symbol: z.string(),
+        decimals: z.number(),
+
+        // -- token --
+        total_supply: z.number(),
+        holders: z.number(),
+
+        // -- chain --
+        network_id: networkIdSchema,
+    })),
+    meta: z.optional(metaSchema),
+});
+
+const openapi = describeRoute({
+    description: 'Token Holders by Contract Address',
+    tags: ['EVM'],
+    security: [{ bearerAuth: [] }],
+    responses: {
+        200: {
+            description: 'Successful Response',
+            content: {
+                'application/json': {
+                    schema: resolver(responseSchema), example: {
+                        data: [
+                            {
+                                "date": "2025-03-18",
+                                "timestamp": "2025-03-18 15:46:59",
+                                "block_num": 22074750,
+                                "address": "0xc944e90c64b2c07662a292be6244bdf05cda44a7",
+                                "name": "Graph Token",
+                                "symbol": "GRT",
+                                "decimals": 18,
+                                "network_id": "mainnet",
+                                "total_supply": "10803355950136852966436018411",
+                                "holders": 170086
+                            }
+                        ]
+                    }
+                },
+            },
+        }
+    },
+});
+
+route.get('/:contract', openapi, validator('param', paramSchema), validator('query', querySchema), async (c) => {
+    const parseContract = evmAddressSchema.safeParse(c.req.param("contract"));
+    if (!parseContract.success) return c.json({ error: `Invalid EVM contract: ${parseContract.error.message}` }, 400);
+
+    const contract = parseContract.data;
+    const network_id = networkIdSchema.safeParse(c.req.query("network_id")).data ?? DEFAULT_NETWORK_ID;
+    const database = `${network_id}:${EVM_SUBSTREAMS_VERSION}`;
+
+    const query = sqlQueries['tokens_for_contract']?.['evm'];
+    if (!query) return c.json({ error: 'Query for tokens could not be loaded' }, 500);
+
+    return makeUsageQuery(c, [query], { contract, network_id }, database);
+});
+
+export default route;

--- a/src/routes/token/tokens/index.ts
+++ b/src/routes/token/tokens/index.ts
@@ -1,0 +1,8 @@
+import { Hono } from 'hono'
+import evm from "./evm.js";
+
+const router = new Hono()
+
+router.route('/evm', evm)
+
+export default router

--- a/src/routes/token/transfers/evm.ts
+++ b/src/routes/token/transfers/evm.ts
@@ -90,7 +90,7 @@ route.get('/:address', openapi, validator('param', paramSchema), validator('quer
     const query = sqlQueries['transfers_for_account']?.['evm']; // TODO: Load different chain_type queries based on network_id
     if (!query) return c.json({ error: 'Query for balances could not be loaded' }, 500);
 
-    return makeUsageQuery(c, [query], { address, age, network_id, contract }, database);
+    return c.json(makeUsageQuery(c, [query], { address, age, network_id, contract }, database));
 });
 
 export default route;

--- a/src/sql/tokens_for_contract/evm.sql
+++ b/src/sql/tokens_for_contract/evm.sql
@@ -1,0 +1,34 @@
+SELECT
+    max(date) as date,
+    max(timestamp) as timestamp,
+    max(block_num) as block_num,
+    contract as address,
+    multiIf(
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id IN ('mainnet','arbitrum-one','base','bnb','matic'), 18,
+        contracts.decimals
+    ) AS decimals,
+    multiIf(
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'mainnet', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'arbitrum-one', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'base', 'ETH',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'bnb', 'BNB',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'matic', 'POL',
+        contracts.symbol
+    ) AS symbol,
+    multiIf(
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'mainnet', 'Ethereum',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'arbitrum-one', 'Arbitrum One',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'base', 'Base',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'bnb', 'BNB',
+        contract IN ('native', '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee') AND network_id = 'matic', 'Polygon',
+        contracts.name
+    ) AS name,
+    {network_id: String} as network_id,
+    CAST(sum(new_balance), 'String') as total_supply,
+    count() as holders
+FROM balances_by_contract FINAL
+LEFT JOIN contracts
+    ON balances_by_contract.contract = contracts.address
+WHERE
+    contract = {contract: String} AND new_balance > 0
+GROUP BY contract, symbol, name, decimals


### PR DESCRIPTION
Includes:
- name/symbol/decimals
- holders (count all owners from  `balances_by_contract`)
- total_supply (sum all balances from  `balances_by_contract`)

Works pretty well, we could most likely expand to include `total_transfers` and also include logo images

<img width="594" alt="image" src="https://github.com/user-attachments/assets/aa95cd32-5e75-4105-a223-b05f9c82e01b" />
